### PR TITLE
Remove dependency on C# 7

### DIFF
--- a/Catalogue.Data/Extensions/RecordExtensions.cs
+++ b/Catalogue.Data/Extensions/RecordExtensions.cs
@@ -9,7 +9,9 @@ namespace Catalogue.Data.Extensions
         {
             var eligible = false;
 
-            if (Uri.TryCreate(record.Path, UriKind.Absolute, out Uri uri))
+            Uri uri;
+
+            if (Uri.TryCreate(record.Path, UriKind.Absolute, out uri))
             {
                 eligible = uri.IsFile;
             }


### PR DESCRIPTION
My VM is really unusable for development work. I can run Topcat on my laptop but I have limited SSD space to install the latest version of VS Studio. If it's OK with you @CathyJinJNCC everything appears to work OK on my laptop if we don't use C# 7 features. This would just be temporarily until I can either get a better VM or a Windows work machine. 

There's only one line of code using C# 7 at the mo anyway!